### PR TITLE
🏡 Home toggle 🎚️

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 PORT=3000
 API_URL=https://api.restful-api.dev
 NODE_ENV=dev
+
+# Feature Flags
+VITE_FEATURE_SEARCH_AS_DEFAULT=false

--- a/.env.example
+++ b/.env.example
@@ -3,4 +3,4 @@ API_URL=https://api.restful-api.dev
 NODE_ENV=dev
 
 # Feature Flags
-VITE_FEATURE_SEARCH_AS_DEFAULT=false
+FEATURE_SEARCH_AS_DEFAULT=false

--- a/Containerfile
+++ b/Containerfile
@@ -8,8 +8,6 @@ RUN npm ci
 COPY client/ ./client/
 COPY *.config.js ./
 
-ENV VITE_FEATURE_SEARCH_AS_DEFAULT=false
-
 RUN npm run build
 
 # Production stage

--- a/Containerfile
+++ b/Containerfile
@@ -7,6 +7,9 @@ RUN npm ci
 # build client side
 COPY client/ ./client/
 COPY *.config.js ./
+
+ENV VITE_FEATURE_SEARCH_AS_DEFAULT=false
+
 RUN npm run build
 
 # Production stage

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
               value: '{{ .Values.input_node }}'
             - name: PORT
               value: '3000'
-            - name: VITE_FEATURE_SEARCH_AS_DEFAULT
+            - name: FEATURE_SEARCH_AS_DEFAULT
               value: '{{ .Values.search_as_default }}'
           securityContext:
             capabilities:

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
             - name: PORT
               value: '3000'
             - name: VITE_FEATURE_SEARCH_AS_DEFAULT
-              value: 'false'
+              value: '{{ .Values.search_as_default }}'
           securityContext:
             capabilities:
               drop:

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -49,6 +49,8 @@ spec:
               value: '{{ .Values.input_node }}'
             - name: PORT
               value: '3000'
+            - name: VITE_FEATURE_SEARCH_AS_DEFAULT
+              value: 'false'
           securityContext:
             capabilities:
               drop:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -3,6 +3,7 @@
 model_endpoint: <MODEL_ENDPOINT>
 input_node: input
 model_name: jukebox
+search_as_default: false
 
 # naming convention for images should take the form 
 # SCENARIO-VERSION 

--- a/client/index.html
+++ b/client/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" href="/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Jukebox AI</title>
+    <script src="/api/refdata/config.js"></script>
   </head>
   <body>
     <div id="app"></div>

--- a/client/src/components/TheNavbar.vue
+++ b/client/src/components/TheNavbar.vue
@@ -1,10 +1,12 @@
 // client/src/components/TheNavbar.vue
 <script setup lang="ts">
 import { ref } from 'vue'
-import { RouterLink } from 'vue-router'
+import { RouterLink, useRoute } from 'vue-router'
 import ThemeToggle from './ThemeToggle.vue'
+import { featureFlags } from '@/utils/featureFlags'
 
 const isMenuOpen = ref(false)
+const route = useRoute()
 
 const toggleMenu = () => {
   isMenuOpen.value = !isMenuOpen.value
@@ -12,6 +14,13 @@ const toggleMenu = () => {
 
 const closeMenu = () => {
   isMenuOpen.value = false
+}
+
+const isActiveRoute = (path: string) => {
+  if (path === '/' && route.path === '/search' && featureFlags.searchAsDefault) {
+    return true;
+  }
+  return route.path === path;
 }
 
 const navItems = [
@@ -38,15 +47,15 @@ const navItems = [
         <div class="hidden md:flex md:items-center">
           <div class="ml-10 flex items-baseline space-x-4">
             <RouterLink
-              v-for="item in navItems"
-              :key="item.path"
-              :to="item.path"
-              class="text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium"
-              :class="{ 'bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-white': $route.path === item.path }"
-              @click="closeMenu"
-            >
-              {{ item.name }}
-            </RouterLink>
+            v-for="item in navItems"
+            :key="item.path"
+            :to="item.path"
+            class="text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white px-3 py-2 rounded-md text-sm font-medium"
+            :class="{ 'bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-white': isActiveRoute(item.path) }"
+            @click="closeMenu"
+          >
+            {{ item.name }}
+          </RouterLink>
           </div>
           <div class="ml-4">
             <ThemeToggle data-cy="theme-toggle" />

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -4,6 +4,9 @@ import HomeView from '../views/HomeView.vue'
 import SearchView from '../views/SearchView.vue'
 import { featureFlags } from '@/utils/featureFlags'
 
+const MAX_REDIRECT = 1;
+let redirectCount = 0;
+
 const router = createRouter({
   history: createWebHistory('/'),
   routes: [
@@ -32,8 +35,10 @@ const router = createRouter({
 
 // Redirect to search page if feature flag is enabled
 router.beforeEach((to, from, next) => {
-  if (to.name === 'home' && featureFlags.searchAsDefault) {
+  if (to.name === 'home' && featureFlags.searchAsDefault && redirectCount < MAX_REDIRECT) {
+    redirectCount++;
     next({ name: 'search' });
+    // next();
   } else {
     next();
   }

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -1,5 +1,8 @@
+// client/src/router/index.ts
 import { createRouter, createWebHistory } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
+import SearchView from '../views/SearchView.vue'
+import { featureFlags } from '@/utils/featureFlags'
 
 const router = createRouter({
   history: createWebHistory('/'),
@@ -12,7 +15,7 @@ const router = createRouter({
     {
       path: '/search',
       name: 'search',
-      component: () => import('../views/SearchView.vue')
+      component: SearchView
     },
     {
       path: '/playlists',
@@ -26,5 +29,14 @@ const router = createRouter({
     }
   ]
 })
+
+// Redirect to search page if feature flag is enabled
+router.beforeEach((to, from, next) => {
+  if (to.name === 'home' && featureFlags.searchAsDefault) {
+    next({ name: 'search' });
+  } else {
+    next();
+  }
+});
 
 export default router

--- a/client/src/utils/featureFlags.ts
+++ b/client/src/utils/featureFlags.ts
@@ -3,12 +3,20 @@ interface FeatureFlags {
   // Add more feature flags here as needed
 }
 
-const getBooleanFromEnv = (key: string, defaultValue: boolean): boolean => {
-  const value = import.meta.env[key];
+// Get a boolean value from runtime config
+const getRuntimeBoolean = (key: string, defaultValue: boolean): boolean => {
+  const config = (window as any).JUKEBOX_CONFIG || {};
+  const value = config[key];
   if (value === undefined) return defaultValue;
-  return value === 'true' || value === '1';
+  return value === true || value === 'true' || value === '1';
 };
 
 export const featureFlags: FeatureFlags = {
-  searchAsDefault: getBooleanFromEnv('VITE_FEATURE_SEARCH_AS_DEFAULT', false),
+  searchAsDefault: getRuntimeBoolean('FEATURE_SEARCH_AS_DEFAULT', false),
+};
+
+// Add a refresh method for when configuration changes
+export const refreshFeatureFlags = () => {
+  featureFlags.searchAsDefault = getRuntimeBoolean('FEATURE_SEARCH_AS_DEFAULT', false);
+  return featureFlags;
 };

--- a/client/src/utils/featureFlags.ts
+++ b/client/src/utils/featureFlags.ts
@@ -1,0 +1,14 @@
+interface FeatureFlags {
+  searchAsDefault: boolean;
+  // Add more feature flags here as needed
+}
+
+const getBooleanFromEnv = (key: string, defaultValue: boolean): boolean => {
+  const value = import.meta.env[key];
+  if (value === undefined) return defaultValue;
+  return value === 'true' || value === '1';
+};
+
+export const featureFlags: FeatureFlags = {
+  searchAsDefault: getBooleanFromEnv('VITE_FEATURE_SEARCH_AS_DEFAULT', false),
+};

--- a/client/src/views/HomeView.vue
+++ b/client/src/views/HomeView.vue
@@ -7,6 +7,7 @@ import ResponseChart from '@/components/ResponseChart.vue'
 import { featureConfigs } from '@/utils/normalization'
 import { songPresets, type SongPreset } from '@/utils/songPresets'
 import WorldMapView from '@/components/WorldMapView.vue'
+import { featureFlags } from '@/utils/featureFlags';
 
 const audioFeatures = ref({
   is_explicit: 0,
@@ -95,6 +96,21 @@ const showLocation = async () => {
 
 <template>
   <div class="max-w-4xl mx-auto px-4">
+
+    <!-- Warning banner when feature flag is enabled -->
+    <div 
+      v-if="featureFlags.searchAsDefault" 
+      class="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-700 p-4 mb-6 rounded"
+      role="alert"
+    >
+      <div class="flex items-center">
+        <svg class="h-5 w-5 mr-2" fill="currentColor" viewBox="0 0 20 20">
+          <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"></path>
+        </svg>
+        <span class="font-medium">Warning:</span>&nbsp;This API is disabled when using the Feast Endpoint
+      </div>
+    </div>
+
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
       <!-- Left Column - Controls -->
       <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -27,8 +27,7 @@ export default defineConfig(({ mode }) => {
       emptyOutDir: true,
     },
     define: {
-      'import.meta.env.INPUT_NODE': JSON.stringify(env.INPUT_NODE || 'input'),
-      'import.meta.env.VITE_FEATURE_SEARCH_AS_DEFAULT': JSON.stringify(env.VITE_FEATURE_SEARCH_AS_DEFAULT)
+      'import.meta.env.INPUT_NODE': JSON.stringify(env.INPUT_NODE || 'input')
     }
   }
 })

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -27,7 +27,8 @@ export default defineConfig(({ mode }) => {
       emptyOutDir: true,
     },
     define: {
-      'import.meta.env.INPUT_NODE': JSON.stringify(env.INPUT_NODE || 'input')
+      'import.meta.env.INPUT_NODE': JSON.stringify(env.INPUT_NODE || 'input'),
+      'import.meta.env.VITE_FEATURE_SEARCH_AS_DEFAULT': JSON.stringify(env.VITE_FEATURE_SEARCH_AS_DEFAULT)
     }
   }
 })

--- a/server.js
+++ b/server.js
@@ -40,6 +40,7 @@ const apiProxy = createProxyMiddleware({
     logLevel: 'debug',
     router: {
         'refdata/song': 'http://0.0.0.0:3000',
+        'refdata/config.js': 'http://0.0.0.0:3000',
         'refdata/world.geojson': 'http://0.0.0.0:3000'
     },
     onProxyReq: (proxyReq, req, res) => {
@@ -71,6 +72,18 @@ app.get('/refdata/songs', (req, res) => {
 
 app.get('/refdata/world.geojson', (req, res) => {
     res.sendFile(path.join(__dirname, 'low-res.geo.json'));
+  });
+
+// Generate runtime config
+app.get('/refdata/config.js', (req, res) => {
+    res.set('Content-Type', 'application/javascript');
+    res.send(`
+      // Runtime configuration - Generated: ${new Date().toISOString()}
+      window.JUKEBOX_CONFIG = {
+        FEATURE_SEARCH_AS_DEFAULT: ${process.env.FEATURE_SEARCH_AS_DEFAULT === 'true'},
+        // Add other runtime configs here
+      };
+    `);
   });
 
 app.get('*', (req, res) => {


### PR DESCRIPTION
OK this one was a bit of a faff to do...  😮‍💨  had to go a bit old school so couple of changes required... 

New format is that when they deploy the `feast-1.4` the `search` view is loaded on launch or refresh of the url (when not on /search) by default as long as `search_as_default: true` on the helm chart - see the other PR for that change (I think in the right place?) 

this should show the user that the new place to use the api is now the "home" page. If someone does swap across to the home page after the app has loaded, they'll see a warning (if `search_as_default: true`  is set) to this api is not working as per screenshot below...

I've set this as a `MAX_REDIRECT` of sorts, set to `1` so the user isn't confused by hitting `home` and ending up on search if that makes sense
 
<img width="1254" alt="Screenshot 2025-03-25 at 16 22 57" src="https://github.com/user-attachments/assets/4756e6d9-abb3-4364-8a41-b341921118ba" />

closes: #3 
